### PR TITLE
Tweak skip warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ var swiftSettings: [SwiftSetting] = [
 ]
 
 // Workaround for https://forums.swift.org/t/warnings-as-errors-in-sub-packages/70810/24
-if ProcessInfo.processInfo.environment["CI"] == "true" {
+if ProcessInfo.processInfo.environment["SKIP_WARNINGS_SWIFTBEANCOUNT"] != "true" {
     swiftSettings.append(contentsOf: [
        .treatAllWarnings(as: .error),
        .treatWarning("SendableClosureCaptures", as: .warning),


### PR DESCRIPTION
Locally works now with Xcode 26.4, but GitHub actions even with the same version still has problems building an app consuming this package.

Will try this and set the Environment Variable in the app build