### PR TITLE
Enhance Wealthsimple duplicate transaction detection for pending and posted transactions

### DIFF
--- a/Sources/SwiftBeanCountWealthsimpleMapper/LedgerLookup.swift
+++ b/Sources/SwiftBeanCountWealthsimpleMapper/LedgerLookup.swift
@@ -36,9 +36,16 @@ struct LedgerLookup {
         guard let id = transaction.metaData.metaData[MetaDataKeys.id] else {
             return false
         }
+        let normalizedIDs = WealthsimpleTransactionID.normalizedIDs(in: id)
         return ledger.transactions.contains {
-            $0.metaData.metaData[MetaDataKeys.id]?.contains(id) ?? false ||
-            $0.metaData.metaData[MetaDataKeys.nrwtId] == id
+            $0.metaData.metaData[MetaDataKeys.id].map {
+                let storedIDs = WealthsimpleTransactionID.normalizedIDs(in: $0)
+                if normalizedIDs.count == 1 {
+                    return storedIDs.isSuperset(of: normalizedIDs)
+                }
+                return storedIDs == normalizedIDs
+            } ?? false ||
+            $0.metaData.metaData[MetaDataKeys.nrwtId].map { normalizedIDs == [WealthsimpleTransactionID.normalized($0)] } ?? false
         }
     }
 

--- a/Sources/SwiftBeanCountWealthsimpleMapper/WealthsimpleLedgerMapper+Helpers.swift
+++ b/Sources/SwiftBeanCountWealthsimpleMapper/WealthsimpleLedgerMapper+Helpers.swift
@@ -13,6 +13,14 @@ import WealthsimpleDownloader
 
 extension WealthsimpleLedgerMapper {
 
+    func normalizedTransactionID(_ id: String) -> String {
+        WealthsimpleTransactionID.normalized(id)
+    }
+
+    func mergedTransactionIDs(_ transactions: [WTransaction]) -> String {
+        transactions.map { normalizedTransactionID($0.id) }.sorted().joined(separator: " ")
+    }
+
     func processRegularTransactions(_ regular: [WTransaction], nrwt: [WTransaction]) throws -> RegularTransactionsResult {
         var prices = [Price](), transactions = [STransaction]()
         var mergedNRWTIds = Set<String>()
@@ -126,7 +134,7 @@ extension WealthsimpleLedgerMapper {
             Posting(accountName: outAccountName, amount: outTransaction.netCash)
         ]
 
-        let mergedId = group.map(\.id).sorted().joined(separator: " ")
+        let mergedId = mergedTransactionIDs(group)
         let meta = TransactionMetaData(
             date: inTransaction.processDate,
             metaData: [MetaDataKeys.id: mergedId]
@@ -147,7 +155,7 @@ extension WealthsimpleLedgerMapper {
         let sourceAmount = Amount(for: sellTransaction.quantity, in: try lookup.commoditySymbol(for: sellTransaction.symbol))
         let targetAmount = Amount(for: buyTransaction.quantity, in: try lookup.commoditySymbol(for: buyTransaction.symbol))
         let totalPrice = Amount(for: sellTransaction.marketValueAmount, in: try lookup.commoditySymbol(for: sellTransaction.symbol))
-        let mergedId = group.map(\.id).sorted().joined(separator: " ")
+        let mergedId = mergedTransactionIDs(group)
 
         return try STransaction(
             metaData: TransactionMetaData(date: buyTransaction.processDate, metaData: [MetaDataKeys.id: mergedId]),

--- a/Sources/SwiftBeanCountWealthsimpleMapper/WealthsimpleLedgerMapper+TransactionMapping.swift
+++ b/Sources/SwiftBeanCountWealthsimpleMapper/WealthsimpleLedgerMapper+TransactionMapping.swift
@@ -43,7 +43,8 @@ extension WealthsimpleLedgerMapper {
     }
 
     func mapBuy(_ transaction: WTransaction, in account: WAccount) throws -> (Price, STransaction) {
-        let result = STransaction(metaData: TransactionMetaData(date: transaction.processDate, metaData: [MetaDataKeys.id: transaction.id]), postings: [
+        let metaData = TransactionMetaData(date: transaction.processDate, metaData: [MetaDataKeys.id: normalizedTransactionID(transaction.id)])
+        let result = STransaction(metaData: metaData, postings: [
             Posting(accountName: try lookup.ledgerAccountName(of: account), amount: transaction.netCash, price: transaction.useFx ? transaction.fxAmount : nil),
             Posting(accountName: try lookup.ledgerAccountName(of: account, symbol: transaction.symbol),
                     amount: Amount(for: transaction.quantity, in: try lookup.commoditySymbol(for: transaction.symbol)),
@@ -53,7 +54,8 @@ extension WealthsimpleLedgerMapper {
     }
 
     func mapSell(_ transaction: WTransaction, in account: WAccount) throws -> (Price, STransaction) {
-        let result = STransaction(metaData: TransactionMetaData(date: transaction.processDate, metaData: [MetaDataKeys.id: transaction.id]), postings: [
+        let metaData = TransactionMetaData(date: transaction.processDate, metaData: [MetaDataKeys.id: normalizedTransactionID(transaction.id)])
+        let result = STransaction(metaData: metaData, postings: [
             Posting(accountName: try lookup.ledgerAccountName(of: account), amount: transaction.netCash, price: transaction.useFx ? transaction.fxAmount : nil),
             Posting(accountName: try lookup.ledgerAccountName(of: account, symbol: transaction.symbol),
                     amount: Amount(for: transaction.quantity, in: try lookup.commoditySymbol(for: transaction.symbol)),
@@ -78,8 +80,13 @@ extension WealthsimpleLedgerMapper {
         let posting1 = Posting(accountName: try lookup.ledgerAccountName(of: account), amount: transaction.netCash)
         let posting2 = try Posting(accountName: accountName, amount: amount, price: price, priceType: hasFX ? .total : nil)
         let narration = includeDescription ? transaction.description : ""
-        return STransaction(metaData: TransactionMetaData(date: transaction.processDate, payee: payee, narration: narration, metaData: [MetaDataKeys.id: transaction.id]),
-                            postings: [posting1, posting2])
+        let metaData = TransactionMetaData(
+            date: transaction.processDate,
+            payee: payee,
+            narration: narration,
+            metaData: [MetaDataKeys.id: normalizedTransactionID(transaction.id)]
+        )
+        return STransaction(metaData: metaData, postings: [posting1, posting2])
     }
 
     func mapContribution(_ transaction: WTransaction, in account: WAccount) throws -> STransaction {
@@ -96,7 +103,8 @@ extension WealthsimpleLedgerMapper {
             postings.append(Posting(accountName: contributionAsset, amount: amount1))
             postings.append(Posting(accountName: contributionExpense, amount: amount2))
         }
-        return STransaction(metaData: TransactionMetaData(date: transaction.processDate, metaData: [MetaDataKeys.id: transaction.id]), postings: postings)
+        let metaData = TransactionMetaData(date: transaction.processDate, metaData: [MetaDataKeys.id: normalizedTransactionID(transaction.id)])
+        return STransaction(metaData: metaData, postings: postings)
     }
 
     func mapDividend(_ transaction: WTransaction, in account: WAccount, manufactured: Bool = false) throws(WealthsimpleConversionError) -> STransaction {
@@ -109,7 +117,7 @@ extension WealthsimpleLedgerMapper {
         }
         let posting1 = Posting(accountName: try lookup.ledgerAccountName(of: account), amount: transaction.netCash, price: price)
         let posting2 = Posting(accountName: try lookup.ledgerAccountName(for: .dividend(transaction.symbol), in: account, ofType: [.income]), amount: income)
-        var metaDataDict = [MetaDataKeys.id: transaction.id]
+        var metaDataDict = [MetaDataKeys.id: normalizedTransactionID(transaction.id)]
         if let date {
             metaDataDict[MetaDataKeys.dividendRecordDate] = date
         }
@@ -121,7 +129,8 @@ extension WealthsimpleLedgerMapper {
     }
 
     func mapStockDividend(_ transaction: WTransaction, in account: WAccount) throws -> (Price, STransaction) {
-        let result = STransaction(metaData: TransactionMetaData(date: transaction.processDate, metaData: [MetaDataKeys.id: transaction.id]), postings: [
+        let metaData = TransactionMetaData(date: transaction.processDate, metaData: [MetaDataKeys.id: normalizedTransactionID(transaction.id)])
+        let result = STransaction(metaData: metaData, postings: [
             Posting(accountName: try lookup.ledgerAccountName(for: .dividend(transaction.symbol), in: account, ofType: [.income]), amount: transaction.negatedMarketValue),
             Posting(accountName: try lookup.ledgerAccountName(of: account, symbol: transaction.symbol),
                     amount: Amount(for: transaction.quantity, in: try lookup.commoditySymbol(for: transaction.symbol)),
@@ -135,7 +144,8 @@ extension WealthsimpleLedgerMapper {
         let price = Amount(number: transaction.fxAmount.number, commoditySymbol: amount.commoditySymbol, decimalDigits: transaction.fxAmount.decimalDigits)
         let posting1 = Posting(accountName: try lookup.ledgerAccountName(of: account), amount: transaction.netCash, price: price)
         let posting2 = Posting(accountName: try lookup.ledgerAccountName(for: .transactionType(transaction.transactionType), in: account, ofType: [.expense]), amount: amount)
-        return STransaction(metaData: TransactionMetaData(date: transaction.processDate, metaData: [MetaDataKeys.id: transaction.id]), postings: [posting1, posting2])
+        let metaData = TransactionMetaData(date: transaction.processDate, metaData: [MetaDataKeys.id: normalizedTransactionID(transaction.id)])
+        return STransaction(metaData: metaData, postings: [posting1, posting2])
     }
 
     func mapStockSplits(_ transactions: [WTransaction], in account: WAccount) throws -> [STransaction] {
@@ -158,7 +168,11 @@ extension WealthsimpleLedgerMapper {
               let sellTransaction = transactions.first(where: { $0.quantity.starts(with: "-") }) else {
             throw WealthsimpleConversionError.unexpectedStockSplit(transactions.first!.description)
         }
-        let metaData = TransactionMetaData(date: buyTransaction.processDate, narration: buyTransaction.description, metaData: [MetaDataKeys.id: buyTransaction.id])
+        let metaData = TransactionMetaData(
+            date: buyTransaction.processDate,
+            narration: buyTransaction.description,
+            metaData: [MetaDataKeys.id: normalizedTransactionID(buyTransaction.id)]
+        )
         return STransaction(metaData: metaData, postings: [
             Posting(accountName: try lookup.ledgerAccountName(of: account, symbol: sellTransaction.symbol),
                     amount: Amount(for: sellTransaction.quantity, in: try lookup.commoditySymbol(for: sellTransaction.symbol)),

--- a/Sources/SwiftBeanCountWealthsimpleMapper/WealthsimpleLedgerMapper.swift
+++ b/Sources/SwiftBeanCountWealthsimpleMapper/WealthsimpleLedgerMapper.swift
@@ -243,7 +243,7 @@ public struct WealthsimpleLedgerMapper {
 
                 // Merge all IDs (sorted for consistent ordering)
                 var ids = result.metaData.metaData
-                ids[MetaDataKeys.id] = group.map(\.id).sorted().joined(separator: " ")
+                ids[MetaDataKeys.id] = mergedTransactionIDs(group)
                 let meta = TransactionMetaData(date: result.metaData.date, payee: result.metaData.payee, narration: result.metaData.narration, metaData: ids)
                 results.append(STransaction(metaData: meta, postings: result.postings))
             } else {

--- a/Sources/SwiftBeanCountWealthsimpleMapper/WealthsimpleTransactionID.swift
+++ b/Sources/SwiftBeanCountWealthsimpleMapper/WealthsimpleTransactionID.swift
@@ -1,0 +1,31 @@
+//
+//  WealthsimpleTransactionID.swift
+//  SwiftBeanCountWealthsimpleMapper
+//
+//  Created by Steffen Kötte on 2026-07-25.
+//
+
+import Foundation
+
+enum WealthsimpleTransactionID {
+
+    private static let cardActivityPrefix = "card-activity-"
+    private static let postedCardActivityComponentCount = 8
+
+    static func normalized(_ id: String) -> String {
+        guard id.hasPrefix(cardActivityPrefix) else {
+            return id
+        }
+
+        let components = id.split(separator: "-")
+        guard components.count == postedCardActivityComponentCount else {
+            return id
+        }
+
+        return components.dropLast().joined(separator: "-")
+    }
+
+    static func normalizedIDs(in value: String) -> Set<String> {
+        Set(value.split(separator: " ").map { normalized(String($0)) })
+    }
+}

--- a/Tests/SwiftBeanCountImporterTests/Importers/WealthsimpleDownloadImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/Importers/WealthsimpleDownloadImporterTests.swift
@@ -272,6 +272,81 @@ struct WealthsimpleDownloadImporterTests { // swiftlint:disable:this type_body_l
     }
 
     @Test
+    func loadTransactionsSuppressesPostedCardActivityDuplicate() throws {
+        let pendingID = "card-activity-12345678901234567890-MC-01-1234567890123456-TESTABC"
+        let postedID = "\(pendingID)-0tifr2if9xlg"
+
+        let ledger = Ledger()
+        try ledger.add(SwiftBeanCountModel.Account(name: try AccountName("Assets:W:Cash"), metaData: ["importer-type": "wealthsimple", "number": "A1B2"]))
+        try ledger.add(Commodity(symbol: "CAD"))
+        ledger.add(STransaction(metaData: TransactionMetaData(date: Date(), metaData: ["wealthsimple-id": pendingID]), postings: []))
+
+        let importer = WealthsimpleDownloadImporter(ledger: ledger)
+        let account = TestAccount()
+        var transaction = TestTransaction()
+        transaction.id = postedID
+        transaction.transactionType = .paymentSpend
+        transaction.symbol = "CAD"
+        transaction.quantity = "-11.76"
+        transaction.netCashAmount = "-11.76"
+
+        getAccountsClosure = { .success([account]) }
+        getPositionsClosure = { _, _ in .success([]) }
+        getTransactionsClosure = { _, _ in .success([transaction]) }
+
+        importer.downloaderClass = TestDownloader.self
+        importer.load()
+
+        #expect(importer.nextTransaction() == nil)
+        #expect(importer.pricesToImport().isEmpty)
+        #expect(importer.balancesToImport().isEmpty)
+    }
+
+    @Test
+    func loadTransactionsSuppressesMergedCashbackDuplicate() throws {
+        let ledger = Ledger()
+        try ledger.add(SwiftBeanCountModel.Account(name: try AccountName("Assets:W:Cash"), metaData: ["importer-type": "wealthsimple", "number": "A1B2"]))
+        try ledger.add(SwiftBeanCountModel.Account(name: try AccountName("Income:Cashback"), metaData: ["wealthsimple-cashback-bonus": "A1B2"]))
+        try ledger.add(Commodity(symbol: "CAD"))
+
+        let existingID = "transaction-7oaJAJOSvSMGndrXgKGYahyYDRM transaction-IxPwJZB66GTF2x0X7HIE1BQLu4 transaction-cWzbd9e2iy8ys9jJJamDO1D3rwI"
+        ledger.add(STransaction(metaData: TransactionMetaData(date: Date(), metaData: ["wealthsimple-id": existingID]), postings: []))
+
+        let importer = WealthsimpleDownloadImporter(ledger: ledger)
+        let account = TestAccount()
+        let date = Date(timeIntervalSinceReferenceDate: 5_645_145_697)
+        let description = "Cashback credit paid at 2026-01-26 for $23.1700"
+        var transaction1 = TestTransaction()
+        transaction1.id = "transaction-7oaJAJOSvSMGndrXgKGYahyYDRM"
+        transaction1.transactionType = .cashbackBonus
+        transaction1.description = description
+        transaction1.symbol = "CAD"
+        transaction1.quantity = "-23.17"
+        transaction1.netCashAmount = "-23.17"
+        transaction1.marketValueAmount = "-23.17"
+        transaction1.processDate = date
+        transaction1.effectiveDate = date
+        var transaction2 = transaction1
+        transaction2.id = "transaction-IxPwJZB66GTF2x0X7HIE1BQLu4"
+        transaction2.quantity = "23.17"
+        transaction2.netCashAmount = "23.17"
+        transaction2.marketValueAmount = "23.17"
+        var transaction3 = transaction2
+        transaction3.id = "transaction-cWzbd9e2iy8ys9jJJamDO1D3rwI"
+
+        getAccountsClosure = { .success([account]) }
+        getPositionsClosure = { _, _ in .success([]) }
+        getTransactionsClosure = { _, _ in .success([transaction1, transaction2, transaction3]) }
+
+        importer.downloaderClass = TestDownloader.self
+        importer.load()
+
+        #expect(importer.nextTransaction() == nil)
+        #expect(importer.pricesToImport().isEmpty)
+        #expect(importer.balancesToImport().isEmpty)
+    }
+
+    @Test
     func loadPositions() throws {
         let ledger = Ledger()
         try ledger.add(SwiftBeanCountModel.Account(name: try AccountName("Assets:W:Cash"), metaData: ["importer-type": "wealthsimple", "number": "A1B2"]))

--- a/Tests/SwiftBeanCountImporterTests/Importers/WealthsimpleDownloadImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/Importers/WealthsimpleDownloadImporterTests.swift
@@ -303,7 +303,7 @@ struct WealthsimpleDownloadImporterTests { // swiftlint:disable:this type_body_l
     }
 
     @Test
-    func loadTransactionsSuppressesMergedCashbackDuplicate() throws {
+    func loadTransactionsSuppressesMergedCashbackDuplicate() throws { // swiftlint:disable:this function_body_length
         let ledger = Ledger()
         try ledger.add(SwiftBeanCountModel.Account(name: try AccountName("Assets:W:Cash"), metaData: ["importer-type": "wealthsimple", "number": "A1B2"]))
         try ledger.add(SwiftBeanCountModel.Account(name: try AccountName("Income:Cashback"), metaData: ["wealthsimple-cashback-bonus": "A1B2"]))

--- a/Tests/SwiftBeanCountWealthsimpleMapperTests/WealthsimpleLedgerMapperTests.swift
+++ b/Tests/SwiftBeanCountWealthsimpleMapperTests/WealthsimpleLedgerMapperTests.swift
@@ -246,6 +246,44 @@ struct WealthsimpleLedgerMapperTests { // swiftlint:disable:this type_body_lengt
     }
 
     @Test
+    func mapTransactionsPendingCardActivityMatchesPostedID() throws {
+        let pendingID = "card-activity-12345678901234567890-MC-01-1234567890123456-TESTABC"
+        let postedID = "\(pendingID)-0tifr2if9xlg"
+        ledger.add(Transaction(metaData: TransactionMetaData(date: Date(), metaData: [MetaDataKeys.id: pendingID]), postings: []))
+
+        var transaction = testTransaction
+        transaction.id = postedID
+        transaction.transactionType = .paymentSpend
+        transaction.symbol = "CAD"
+        transaction.quantity = "-11.76"
+        transaction.netCashAmount = "-11.76"
+
+        let (prices, transactions) = try mapper.mapTransactionsToPriceAndTransactions([transaction])
+
+        #expect(prices.isEmpty)
+        #expect(transactions.isEmpty)
+    }
+
+    @Test
+    func mapTransactionsPostedCardActivityStoresNormalizedID() throws {
+        let pendingID = "card-activity-12345678901234567890-MC-01-1234567890123456-TESTABC"
+        let postedID = "\(pendingID)-0tifr2if9xlg"
+
+        var transaction = testTransaction
+        transaction.id = postedID
+        transaction.transactionType = .paymentSpend
+        transaction.symbol = "CAD"
+        transaction.quantity = "-11.76"
+        transaction.netCashAmount = "-11.76"
+
+        let (prices, transactions) = try mapper.mapTransactionsToPriceAndTransactions([transaction])
+
+        #expect(prices.isEmpty)
+        #expect(transactions.count == 1)
+        #expect(transactions.first?.metaData.metaData[MetaDataKeys.id] == pendingID)
+    }
+
+    @Test
     func mapTransactionsNRWT() throws {
         var nrwt = testTransaction
         nrwt.transactionType = .nonResidentWithholdingTax
@@ -562,6 +600,26 @@ struct WealthsimpleLedgerMapperTests { // swiftlint:disable:this type_body_lengt
         #expect(transactions.count == 1)
         #expect(transactions.first?.metaData.metaData[MetaDataKeys.id] == mergedId)
         #expect(transactions == [expectedTransaction])
+    }
+
+    @Test
+    func mapCashbackTransactionsAlreadyExisting() throws {
+        let incomeAccount = try AccountName("Income:Cashback")
+        try ledger.add(SAccount(name: incomeAccount, metaData: ["\(MetaDataKeys.prefix)cashback-bonus": accountNumber]))
+
+        let date = Date(timeIntervalSinceReferenceDate: 5_645_145_697)
+        let description = "Cashback credit paid at 2026-01-26 for $23.1700"
+        let transaction1 = cashbackTransaction(id: "transaction-7oaJAJOSvSMGndrXgKGYahyYDRM", quantity: "-23.17", netCash: "-23.17", date: date, description: description)
+        let transaction2 = cashbackTransaction(id: "transaction-IxPwJZB66GTF2x0X7HIE1BQLu4", quantity: "23.17", netCash: "23.17", date: date, description: description)
+        let transaction3 = cashbackTransaction(id: "transaction-cWzbd9e2iy8ys9jJJamDO1D3rwI", quantity: "23.17", netCash: "23.17", date: date, description: description)
+        let mergedId = "transaction-7oaJAJOSvSMGndrXgKGYahyYDRM transaction-IxPwJZB66GTF2x0X7HIE1BQLu4 transaction-cWzbd9e2iy8ys9jJJamDO1D3rwI"
+
+        ledger.add(Transaction(metaData: TransactionMetaData(date: date, metaData: [MetaDataKeys.id: mergedId]), postings: []))
+
+        let (prices, transactions) = try mapper.mapTransactionsToPriceAndTransactions([transaction1, transaction2, transaction3])
+
+        #expect(prices.isEmpty)
+        #expect(transactions.isEmpty)
     }
 
     @Test


### PR DESCRIPTION
## Summary
Fix Wealthsimple duplicate detection so re-imports do not surface transactions that are already in the ledger.

## What Changed
- normalize Wealthsimple card activity IDs so pending and posted versions of the same card transaction match during duplicate lookup
- store normalized Wealthsimple IDs for future mapped transactions
- fix duplicate lookup for merged Wealthsimple transactions such as cashback entries that persist multiple space-separated IDs in one `wealthsimple-id`
- add mapper and importer regressions for posted card activities and already-imported merged cashback transactions

## Validation
- `swift test --filter WealthsimpleLedgerMapperTests`
- `swift test --filter WealthsimpleDownloadImporterTests`
- earlier in the session: full `swift build` and full `swift test` passed