### PR TITLE
Fix ManuLife interest note parsing

### DIFF
--- a/Sources/SwiftBeanCountImporter/Importers/ManuLifeImporter.swift
+++ b/Sources/SwiftBeanCountImporter/Importers/ManuLifeImporter.swift
@@ -252,7 +252,7 @@ class ManuLifeImporter: BaseImporter, TransactionBalanceTextImporter {
     ///   - commodities: dictionary of name to account for commodities
     /// - Returns: Tupel with ManuLifeBuys and the purchase date
     private func parsePurchase(string input: String, commodities: [String: String]) -> ([ManuLifeBuy], Date?) {
-        let pattern = #"\s*.*?\.gif\s*(\d{4}.*?[a-z]\d)\s*$\s*[a-zA-z]*[ ]?(?:Contribution|Fund Transfer|Withdrawal)\s*([0-9.,]*)\s*units\s*@\s*\$([0-9.,]*)/unit\s*(-?[0-9.,]*)\s*$"# // swiftlint:disable:this line_length
+        let pattern = #"\s*.*?\.gif\s*(\d{4}.*?[a-z]\d)\s*$\s*[a-zA-z]*[ ]?(?:Contribution|Fund Transfer|Withdrawal)\s*([0-9.,]*)\s*units\s*@\s*\$([0-9.,]*)/unit(?:\s*\([^\r\n]*\))?\s*(-?[0-9.,]*)\s*$"# // swiftlint:disable:this line_length
 
         // swiftlint:disable force_try
         let dateRegex = try! NSRegularExpression(pattern: #"^(.*?) [a-zA-z]*[ ]?(?:Contribution|Fund Transfer|Withdrawal) \(Ref."#, options: [.anchorsMatchLines])

--- a/Tests/SwiftBeanCountImporterTests/Importers/ManuLifeImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/Importers/ManuLifeImporterTests.swift
@@ -62,6 +62,21 @@ private let transaction = """
 
     """
 
+private let transactionWithInterestNote = """
+
+    Transaction details
+    July 15, 2025 Contribution (Ref.# 12345678)
+
+    To:\t\t\tAmount($)
+    ../Images/colour10.gif\t 1234 ML Sample Balanced Fund a1 b2
+    Contribution 3.50000 units @ $20.000/unit (includes $0.01 interest)\t70.00
+    Total\t\t70.00
+    ../Images/colour4.gif\t 5678 ML Sample Equity Fund c3 d4
+    Contribution 2.00000 units @ $15.000/unit (includes $0.01 interest)\t30.00
+    Total\t\t30.00
+
+    """
+
 private let transactionInvalidDate = """
     Transaction details
     May -0, 2020 Contribution (Ref.# 12345678)
@@ -208,6 +223,15 @@ struct ManuLifeImporterTests { // swiftlint:disable:this type_body_length
             "\(transactionResult())\n\n\(transactionPricesResult())"
         )
         #expect(parkingAccountDelegate.verified)
+    }
+
+    @Test
+    func parseTransactionWithInterestNote() throws {
+        let importer = loadedImporter(ledger: try TestUtils.ledgerManuLife(), transaction: transactionWithInterestNote)
+
+        #expect(importer.nextTransaction() != nil)
+        #expect(importer.pricesToImport().count == 2)
+        #expect(importer.nextTransaction() == nil)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- ignore parenthetical notes after a ManuLife unit price
- add regression coverage for contribution entries that include interest notes

## Tests
- swift test --filter ManuLifeImporterTests